### PR TITLE
Remove unnecessary session_id parameter from handleTokenRequest

### DIFF
--- a/src/OAuth2/Server.php
+++ b/src/OAuth2/Server.php
@@ -457,7 +457,7 @@ class Server implements ResourceControllerInterface, AuthorizeControllerInterfac
      *
      * @ingroup oauth2_section_4
      */
-    public function handleTokenRequest(RequestInterface $request, ResponseInterface $response = null, ?string $session_id = null)
+    public function handleTokenRequest(RequestInterface $request, ResponseInterface $response = null)
     {
         $this->response = is_null($response) ? new Response() : $response;
 

--- a/test/OAuth2/OpenID/Controller/LogoutControllerTest.php
+++ b/test/OAuth2/OpenID/Controller/LogoutControllerTest.php
@@ -43,7 +43,7 @@ class LogoutControllerTest extends TestCase
             'code' => 'testcode2',
         ));
 
-        $server->handleTokenRequest($request, $response = new Response(), $session_id);
+        $server->handleTokenRequest($request, $response = new Response());
 
         $session = $this->storage->getSession($session_id);
         $sessionTokens = $this->storage->getSessionTokens($session_id);


### PR DESCRIPTION
This function does not depend on the session_id but will internally resolve the session instead. The parameter is therefor misleading