### PR TITLE
chore: raise PHP minimum to 8.2, refresh CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         options: --health-cmd="pg_isready -h localhost" --health-interval=10s --health-timeout=5s --health-retries=5
     strategy:
       matrix:
-        php: [ 8.1, 8.2 ]
+        php: [ 8.2, 8.3, 8.4, 8.5 ]
     name: "PHP ${{ matrix.php }} Unit Test"
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.4
       - name: Install composer dependencies
         uses: nick-invision/retry@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,4 @@ jobs:
           max_attempts: 3
           command: composer install
       - name: Run PHPStan
-        run: |
-          composer require phpstan/phpstan
-          vendor/bin/phpstan analyse --level=0 src/
+        run: vendor/bin/phpstan analyse --level=0 src/

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "psr-0": { "OAuth2": "src/" }
     },
 	"require": {
-		"php":">=8.1",
+		"php":">=8.2",
 		"guzzlehttp/guzzle": "^7.8",
 		"web-token/jwt-library": "^3.3"
 	},


### PR DESCRIPTION
## Summary
PHP 8.1 reached end of security support in December 2025, so the supported floor moves up to 8.2. This PR aligns both the package contract and the CI surface, and cleans up the leftover ad-hoc PHPStan install that #22 couldn't touch (token-scope issue).

### Commits

- **`2987880`** — `chore: raise PHP minimum to 8.2 and refresh CI matrix`
  - `composer.json`: `php >=8.1` → `php >=8.2`
  - Unit-test matrix: `[8.1, 8.2]` → `[8.2, 8.3, 8.4, 8.5]`
  - PHPStan job: `php-version 8.1` → `8.4` (second-newest stable, deterministic single runner)
  - No source changes needed — PHP 8.2 is a strict superset of 8.1 for everything this codebase uses.
- **`e84897f`** — `ci: drop ad-hoc PHPStan install, use the version from composer.json`
  - `phpstan/phpstan ^2.0` is now a real `require-dev` dep (since #22), so the workflow's `composer require phpstan/phpstan` line is redundant. Removes it.

## QA performed locally (PHP 8.5.5)
- `composer update` → clean, **0 security advisories**.
- `vendor/bin/phpunit` → **341 tests, 1118 assertions, 0 failures** (60 skips for DB/Redis/Mongo services not available locally, identical to baseline).
- `vendor/bin/phpstan analyse --level=0 src/` → **`[OK] No errors`**.

## Side note (not addressed here)
The workflow trigger is still `on.push.branches: [main]`, but this repo uses `master` — so direct pushes to master don't trigger CI (PRs do, hence we haven't noticed). Worth a tiny follow-up.

## Test plan
- [ ] All four matrix legs (8.2, 8.3, 8.4, 8.5) pass unit tests
- [ ] PHPStan job stays green