### PR TITLE
docs: refresh README CI badge (main branch + GitHub Actions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 oauth2-server-php
 =================
 
-[![Build Status](https://travis-ci.com/reb3r/oauth2-server-php.svg?branch=main)](https://travis-ci.com/reb3r/oauth2-server-php)
+[![Test Suite](https://github.com/reb3r/oauth2-server-php/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/reb3r/oauth2-server-php/actions/workflows/tests.yml)
 
 [![Total Downloads](https://poser.pugx.org/reb3r/oauth2-server-php/downloads)](https://packagist.org/packages/reb3r/oauth2-server-php)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 oauth2-server-php
 =================
 
-[![Build Status](https://travis-ci.com/reb3r/oauth2-server-php.svg?branch=master)](https://travis-ci.com/reb3r/oauth2-server-php)
+[![Build Status](https://travis-ci.com/reb3r/oauth2-server-php.svg?branch=main)](https://travis-ci.com/reb3r/oauth2-server-php)
 
 [![Total Downloads](https://poser.pugx.org/reb3r/oauth2-server-php/downloads)](https://packagist.org/packages/reb3r/oauth2-server-php)
 


### PR DESCRIPTION
## Summary
Two-step refresh of the README's build-status badge:

1. **`161449a`** — \`?branch=master\` → \`?branch=main\` after the repo rename, so the badge URL doesn't dangle on a non-existent ref.
2. **`14949a2`** — Replaces the long-stale Travis CI badge entirely with the GitHub Actions workflow badge. CI hasn't run on travis-ci.com for this fork in years; everything is in \`.github/workflows/tests.yml\`. The badge now reflects actual CI state.

Resulting line:

\`\`\`md
[![Test Suite](https://github.com/reb3r/oauth2-server-php/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/reb3r/oauth2-server-php/actions/workflows/tests.yml)
\`\`\`