### PR TITLE
chore: bump PHPUnit ^9 → ^11 (yoast polyfills ^4)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
           max_attempts: 3
           command: composer install
       - name: Run PHPUnit
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/phpunit
   phpstan:
     name: "PHPStan"
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 composer.lock
 .idea
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,11 @@
 		"web-token/jwt-library": "^3.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9.0",
+		"phpunit/phpunit": "^11.0",
 		"phpstan/phpstan": "^2.0",
 		"firebase/php-jwt": "^7.0",
 		"predis/predis": "^1.1",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^4.0"
 	},
 	"suggest": {
 		"predis/predis": "Required to use Redis storage",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="test/bootstrap.php"
->
+<phpunit backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="test/bootstrap.php" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Oauth2 Test Suite">
       <directory>./test/OAuth2/</directory>
     </testsuite>
   </testsuites>
-
-      <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src/OAuth2/</directory>
-        </include>
-    </coverage>
+  <source>
+    <include>
+      <directory suffix=".php">./src/OAuth2/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/test/OAuth2/Encryption/FirebaseJwtTest.php
+++ b/test/OAuth2/Encryption/FirebaseJwtTest.php
@@ -102,7 +102,7 @@ EOD;
         $this->assertFalse($payload);
     }
 
-    public function provideClientCredentials()
+    public static function provideClientCredentials()
     {
         $storage = Bootstrap::getInstance()->getMemoryStorage();
         $client_id  = 'Test Client ID';

--- a/test/OAuth2/Encryption/JwtTest.php
+++ b/test/OAuth2/Encryption/JwtTest.php
@@ -102,7 +102,7 @@ EOD;
         $this->assertFalse($payload);
     }
 
-    public function provideClientCredentials()
+    public static function provideClientCredentials()
     {
         $storage = Bootstrap::getInstance()->getMemoryStorage();
         $client_id  = 'Test Client ID';

--- a/test/OAuth2/ServerTest.php
+++ b/test/OAuth2/ServerTest.php
@@ -8,11 +8,9 @@ use OAuth2\Request\TestRequest;
 use OAuth2\ResponseType\AuthorizationCode;
 use OAuth2\Storage\Bootstrap;
 use PHPUnit\Framework\TestCase;
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
 class ServerTest extends TestCase
 {
-    use ExpectPHPException;
 
     public function testGetAuthorizeControllerWithNoClientStorageThrowsException()
     {
@@ -513,7 +511,8 @@ class ServerTest extends TestCase
 
     public function testUsingOpenIDConnectWithAllowImplicitWithoutTokenStorageThrowsException()
     {
-        $this->expectErrorMessage('OAuth2\ResponseType\AccessTokenInterface');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('OAuth2\ResponseType\AccessTokenInterface');
         $client = $this->createMock('OAuth2\Storage\ClientInterface');
         $userclaims = $this->createMock('OAuth2\OpenID\Storage\UserClaimsInterface');
         $pubkey = $this->createMock('OAuth2\Storage\PublicKeyInterface');
@@ -591,7 +590,8 @@ class ServerTest extends TestCase
         $token = $this->createMock('OAuth2\Storage\AccessTokenInterface');
         $authcode = $this->createMock('OAuth2\Storage\AuthorizationCodeInterface');
 
-        $this->expectErrorMessage('OAuth2\OpenID\Storage\AuthorizationCodeInterface');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('OAuth2\OpenID\Storage\AuthorizationCodeInterface');
         $server = new Server(array($client, $userclaims, $pubkey, $token, $authcode), array(
             'use_openid_connect' => true,
             'issuer' => 'someguy'

--- a/test/OAuth2/Storage/PdoTest.php
+++ b/test/OAuth2/Storage/PdoTest.php
@@ -2,12 +2,8 @@
 
 namespace OAuth2\Storage;
 
-use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
-
 class PdoTest extends BaseTest
 {
-    use ExpectPHPException;
-
     public function testCreatePdoStorageUsingPdoClass()
     {
         $dsn = sprintf('sqlite:%s', Bootstrap::getInstance()->getSqliteDir());
@@ -36,7 +32,8 @@ class PdoTest extends BaseTest
 
     public function testCreatePdoStorageWithoutDSNThrowsException()
     {
-        $this->expectErrorMessage('dsn');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('dsn');
         $config = array('username' => 'brent', 'password' => 'brentisaballer');
         $storage = new Pdo($config);
     }

--- a/test/lib/OAuth2/Storage/BaseTest.php
+++ b/test/lib/OAuth2/Storage/BaseTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BaseTest extends TestCase
 {
-    public function provideStorage()
+    public static function provideStorage()
     {
         $memory = Bootstrap::getInstance()->getMemoryStorage();
         $sqlite = Bootstrap::getInstance()->getSqlitePdo();


### PR DESCRIPTION
## Summary
PHPUnit 9 has been out of bugfix support since 2024-02-02. PHPUnit 11 is the highest major still installable with our current PHP-min of 8.2 (PHPUnit 12 requires PHP 8.3, PHPUnit 13 requires PHP 8.4). This PR bumps to PHPUnit 11.5.x + yoast/phpunit-polyfills 4.x and brings the test code in line with the BC breaks between 9 and 11.

### Caveat
PHPUnit 11 itself reached bugfix-EOL on 2026-02-06 (just over three months ago). A follow-up bump to PHPUnit 12 will eventually be needed and would require a PHP-min bump to 8.3. Out of scope for this PR — we've decided to keep PHP 8.2 support for now.

### Commits (atomic, in order)

- **`c59c56f`** — `chore: bump phpunit ^9 -> ^11 and yoast/phpunit-polyfills ^1 -> ^4`
- **`b40682d`** — `test: migrate phpunit.xml schema for PHPUnit 11` (auto-migrated via \`--migrate-configuration\`, plus \`.gitignore\` for the new \`.phpunit.cache/\` dir)
- **`f900549`** — `test: make data providers static (required since PHPUnit 10)` (3 providers, all only used \`Bootstrap::getInstance()\`, trivial flip)
- **`155fc36`** — `test: replace removed expectError* API with concrete exception expectations` (the \`Yoast\\PHPUnitPolyfills\\Polyfills\\ExpectPHPException\` trait was dropped in polyfills 4.x; underlying code throws regular Exceptions, so the rewrite is straightforward)

## QA performed locally (PHP 8.5.5)
- \`composer update\` → 0 advisories
- \`vendor/bin/phpunit\` → **341 tests, 1121 assertions, 0 failures** (60 skipped for missing service containers, identical to baseline)
- \`vendor/bin/phpstan analyse --level=0 src/\` → **`[OK] No errors`**

## Known noise (not addressed here, deliberate)
- **19 PHP deprecations** under PHP 8.5 (e.g. `Using null as an array offset`, `ReflectionProperty::setAccessible() is deprecated since 8.5`). These are pre-existing in src/ and tests, surfaced by PHPUnit 11's deprecation reporter — separate clean-up.
- **26 PHPUnit deprecations** for `@dataProvider` doc-comment metadata being dropped in PHPUnit 12. When/if we bump to 12 (which would also require PHP-min 8.3), we migrate those to `#[DataProvider(...)]` attributes.
- **5 risky tests** — `testSetAccessToken` and friends "did not perform any assertions" — same as before this PR.

## Test plan
- [ ] All four matrix legs (8.2, 8.3, 8.4, 8.5) stay green on the new PHPUnit
- [ ] PHPStan stays green