### PR TITLE
chore(deps): upgrade web-token/jwt-library to ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	"require": {
 		"php":">=8.2",
 		"guzzlehttp/guzzle": "^7.8",
-		"web-token/jwt-library": "^3.3"
+		"web-token/jwt-library": "^4.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^11.0",

--- a/test/OAuth2/OpenID/Controller/JWKSetControllerTest.php
+++ b/test/OAuth2/OpenID/Controller/JWKSetControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace OAuth2\OpenID\Controller;
+
+use OAuth2\Storage\Bootstrap;
+use OAuth2\Storage\Memory;
+use OAuth2\Request;
+use OAuth2\Response;
+use PHPUnit\Framework\TestCase;
+
+class JWKSetControllerTest extends TestCase
+{
+    public function testHandleJWKSetRequestReturnsOk()
+    {
+        $controller = new JWKSetController($this->getPublicKeyStorage());
+
+        $response = new Response();
+        $controller->handleJWKSetRequest(new Request(), $response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testHandleJWKSetRequestExposesPublicKey()
+    {
+        $controller = new JWKSetController($this->getPublicKeyStorage());
+
+        $response = new Response();
+        $controller->handleJWKSetRequest(new Request(), $response);
+
+        $parameters = $response->getParameters();
+        $this->assertArrayHasKey('keys', $parameters);
+        $this->assertCount(1, $parameters['keys']);
+
+        $key = $parameters['keys'][0];
+        $this->assertInstanceOf(\Jose\Component\Core\JWK::class, $key);
+        $this->assertEquals('RSA', $key->get('kty'));
+        $this->assertTrue($key->has('n'));
+        $this->assertTrue($key->has('e'));
+    }
+
+    public function testHandleJWKSetRequestNeverExposesPrivateKeyMaterial()
+    {
+        $controller = new JWKSetController($this->getPublicKeyStorage());
+
+        $response = new Response();
+        $controller->handleJWKSetRequest(new Request(), $response);
+
+        $key = $response->getParameters()['keys'][0];
+        // "d" is the RSA private exponent and must never leak through a JWK Set
+        $this->assertFalse($key->has('d'));
+    }
+
+    public function testHandleJWKSetRequestSetsCacheHeaders()
+    {
+        $controller = new JWKSetController($this->getPublicKeyStorage());
+
+        $response = new Response();
+        $controller->handleJWKSetRequest(new Request(), $response);
+
+        $this->assertEquals('no-store', $response->getHttpHeader('Cache-Control'));
+        $this->assertEquals('no-cache', $response->getHttpHeader('Pragma'));
+        $this->assertEquals('application/json', $response->getHttpHeader('Content-Type'));
+    }
+
+    public function testValidateJWKSetRequestAlwaysSucceeds()
+    {
+        $controller = new JWKSetController($this->getPublicKeyStorage());
+
+        $this->assertTrue($controller->validateJWKSetRequest(new Request(), new Response()));
+    }
+
+    private function getPublicKeyStorage(): Memory
+    {
+        return Bootstrap::getInstance()->getMemoryStorage();
+    }
+}


### PR DESCRIPTION
## Summary
Upgrades `web-token/jwt-library` from `^3.3` to `^4.0` (installed: 4.1.7).

The only consumer in the codebase is `JWKSetController`, which uses `JWKFactory::createFromKey()` and `JWKSet`. Both APIs are unchanged in v4, so **no production code changes were required**. v4 requires `php >=8.1`, which is satisfied by the project's `php >=8.2` floor.

## Tests
- Added `JWKSetControllerTest` — the controller was the only jwt-library consumer and previously had **no test coverage**. Covers: 200 status, exposed RSA public key (`kty`/`n`/`e`), absence of private key material (`d`), cache headers, and request validation.
- Full suite green: 346 tests (was 341).
- PHPStan clean on `JWKSetController`.