### PR TITLE
chore(deps): upgrade predis/predis to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"phpunit/phpunit": "^11.0",
 		"phpstan/phpstan": "^2.0",
 		"firebase/php-jwt": "^7.0",
-		"predis/predis": "^1.1",
+		"predis/predis": "^3.0",
 		"yoast/phpunit-polyfills": "^4.0"
 	},
 	"suggest": {


### PR DESCRIPTION
## Summary
Upgrades `predis/predis` (dev dependency) from `^1.1` to `^3.0` (installed: 3.5.1).

predis 3.x requires `php ^7.2 || ^8.0` and is therefore compatible with the project's `php >=8.2` floor. The `Redis` storage only uses stable commands (`get`/`set`/`setex`/`del`), so **no code changes were required**.

## Tests
- Verified against a live Redis 7 server: the storage suite now actually exercises the `Redis` storage backend (previously skipped without a server) and passes — 1263 assertions vs. 1133 without Redis.
- PHPStan clean on `src/OAuth2/Storage/Redis.php`.

## Note
Independent of #29 (jwt-library v4); this branch is based on `main` and keeps `web-token/jwt-library` at `^3.3`.